### PR TITLE
Pivot to paid SaaS model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,25 @@
-# iOS Preflight
+# ReviewShield
 
-A command-line tool that scans iOS app projects for App Store Review Guideline violations before submission.
+🛡️ Catch App Store rejections before they happen.
 
-## Overview
+**Status:** Private Beta
 
-iOS Preflight analyzes your Xcode project to detect common issues that cause App Store rejections:
+## About
 
-- Missing privacy usage descriptions (camera, location, etc.)
-- ATT tracking mismatches
-- Sign in with Apple requirements
-- Entitlements configuration issues
-- And more...
+ReviewShield is a SaaS tool that scans iOS projects for App Store Review Guideline violations. It integrates with GitHub to automatically check PRs and block merges that would cause rejections.
 
-## Installation
+## Product
 
-### Build from Source
+- **GitHub App** — Automatic PR checks
+- **CLI** — Local scanning for development
+- **Dashboard** — History, trends, team management
 
-```bash
-git clone https://github.com/signal26/ios-preflight.git
-cd ios-preflight
-swift build -c release
-cp .build/release/preflight /usr/local/bin/
-```
+## Tech Stack
 
-## Usage
+- TypeScript / Node.js
+- GitHub App (Probot)
+- Vercel (hosting)
 
-### Basic Scan
+---
 
-```bash
-preflight scan ./MyApp.xcodeproj
-```
-
-### JSON Output (for CI)
-
-```bash
-preflight scan ./MyApp.xcodeproj --format json --output report.json
-```
-
-### HTML Report
-
-```bash
-preflight scan ./MyApp.xcodeproj --format html --output report.html
-```
-
-## Exit Codes
-
-| Code | Meaning |
-|------|---------|
-| 0 | Success, no critical or high findings |
-| 1 | Critical or high severity findings present |
-| 2 | Error (invalid path, parse failure, etc.) |
-
-## Project Structure
-
-```
-ios-preflight/
-├── Package.swift
-├── Sources/
-│   ├── PreflightCore/       # Core analysis library
-│   │   ├── Models/          # Data structures
-│   │   ├── Parsers/         # Plist, entitlements parsing
-│   │   ├── Rules/           # Check implementations
-│   │   └── Reports/         # Output formatters
-│   └── PreflightCLI/        # CLI interface
-├── Tests/
-│   └── PreflightCoreTests/
-└── README.md
-```
-
-## License
-
-MIT License - Copyright (c) 2026 Signal26
-
-## Contributing
-
-Contributions welcome! Please read CONTRIBUTING.md before submitting PRs.
+© 2026 Signal26. All rights reserved.

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,150 +1,66 @@
 # ReviewShield
 
-🛡️ App Store Review Guideline scanner for iOS projects
+🛡️ Catch App Store rejections before they happen.
 
-ReviewShield statically analyzes your Xcode project to detect potential App Store Review issues before you submit.
+ReviewShield scans your iOS project for App Store Review Guideline violations and tells you exactly how to fix them.
 
-## Features
+## The Problem
 
-- **5 MVP Rules** covering common rejection reasons:
-  - Missing camera usage description
-  - Missing location usage descriptions
-  - Unjustified Always location permission
-  - Tracking SDKs without App Tracking Transparency
-  - Third-party login without Sign in with Apple
+App Store rejections cost time and money:
+- 2-7 day review delays
+- Missed launch windows
+- Frustrated users waiting for updates
 
-- **Multiple output formats**: Text (human-readable), JSON, SARIF (for CI/CD)
-- **ESLint-style plugin architecture** for easy rule extension
-- **Zero configuration** - just point to your project
+Common culprits: missing privacy descriptions, Sign in with Apple requirements, tracking compliance — all preventable.
 
-## Installation
+## The Solution
+
+ReviewShield catches these issues **before** you submit:
 
 ```bash
-npm install -g reviewshield
+$ reviewshield scan ./MyApp.xcodeproj
+
+🛡️  ReviewShield Scan Results
+
+🔍 Found 2 issue(s):
+
+1. [CRITICAL] Missing Camera Usage Description
+   📍 Info.plist • 📋 Guideline 5.1.1
+   
+   Your app uses AVFoundation but Info.plist is missing 
+   NSCameraUsageDescription...
+   
+   How to fix:
+   Add NSCameraUsageDescription to your Info.plist...
+
+2. [CRITICAL] Third-Party Login Without Sign in with Apple
+   📍 Entitlements • 📋 Guideline 4.8
+   
+   Your app includes Google Sign-In but Sign in with Apple 
+   is not configured...
 ```
 
-Or use directly with npx:
+## What We Check
 
-```bash
-npx reviewshield scan /path/to/project
-```
+| Category | Rules |
+|----------|-------|
+| **Privacy** | Camera, Location, Microphone, Photos, Contacts usage descriptions |
+| **Tracking** | ATT compliance, tracking SDK detection |
+| **Authentication** | Sign in with Apple requirements |
+| **Security** | App Transport Security, Privacy Manifests (iOS 17+) |
 
-## Usage
+10 rules today, more coming weekly.
 
-### Basic Scan
+## Getting Started
 
-```bash
-reviewshield scan /path/to/MyApp.xcodeproj
-```
+**Coming soon:** ReviewShield GitHub App — automatic PR checks, no setup required.
 
-### Output Formats
+Join the waitlist: [reviewshield.dev](https://reviewshield.dev)
 
-```bash
-# Human-readable text (default)
-reviewshield scan /path/to/project
+## For Early Access
 
-# JSON for scripting
-reviewshield scan /path/to/project --format json
+Contact us at hello@signal26.dev for beta access.
 
-# SARIF for CI/CD (GitHub, Azure DevOps)
-reviewshield scan /path/to/project --format sarif
-```
+---
 
-### List Available Rules
-
-```bash
-reviewshield rules
-```
-
-### Run Specific Rules Only
-
-```bash
-reviewshield scan /path/to/project --rules privacy-001-missing-camera-purpose privacy-002-missing-location-purpose
-```
-
-### Exclude Rules
-
-```bash
-reviewshield scan /path/to/project --exclude auth-001-third-party-login-no-siwa
-```
-
-## Rules
-
-| ID | Name | Guideline | Severity |
-|----|------|-----------|----------|
-| `privacy-001-missing-camera-purpose` | Missing Camera Usage Description | 5.1.1 | Critical |
-| `privacy-002-missing-location-purpose` | Missing Location Usage Description | 5.1.1 | Critical |
-| `entitlements-001-location-always-unjustified` | Location Always Without Justification | 5.1.1 | Critical |
-| `privacy-003-att-tracking-mismatch` | Tracking SDK Without ATT | 5.1.2 | Critical |
-| `auth-001-third-party-login-no-siwa` | Third-Party Login Without SIWA | 4.8 | Critical |
-
-## Programmatic Usage
-
-```typescript
-import { scan, OutputFormat } from 'reviewshield';
-
-const result = await scan({
-  path: '/path/to/project',
-  format: OutputFormat.JSON,
-  verbose: false,
-});
-
-console.log(`Found ${result.findings.length} issues`);
-
-for (const finding of result.findings) {
-  console.log(`[${finding.severity}] ${finding.title}`);
-  console.log(`  ${finding.description}`);
-}
-```
-
-## CI/CD Integration
-
-### GitHub Actions
-
-```yaml
-name: App Store Review Check
-
-on: [push, pull_request]
-
-jobs:
-  reviewshield:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      
-      - name: Install ReviewShield
-        run: npm install -g reviewshield
-      
-      - name: Run ReviewShield
-        run: reviewshield scan . --format sarif > reviewshield.sarif
-      
-      - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: reviewshield.sarif
-```
-
-## Development
-
-```bash
-# Install dependencies
-npm install
-
-# Build
-npm run build
-
-# Run tests
-npm test
-
-# Run in development mode
-npm run dev -- scan /path/to/project
-```
-
-## License
-
-MIT
+© 2026 Signal26. All rights reserved.


### PR DESCRIPTION
## Changes

- Updated README for commercial product positioning
- Removed MIT license (proprietary for now)
- Focus on GitHub App as primary product
- CLI available for beta users only

## Strategy

Start with paid SaaS, consider open-sourcing CLI later once we have paying customers.

**Pricing:**
- $9/mo per repo
- $29/mo unlimited

**Path to $300 MRR:** 11 users at $29/mo