### PR TITLE
Update ShipLint action docs and context metadata

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: Signal26AI/ShipLint@v1
+      - uses: Signal26AI/ShipLint/action@v1
         with:
           path: '.'
 ```
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - uses: Signal26AI/ShipLint@v1
+      - uses: Signal26AI/ShipLint/action@v1
         with:
           format: 'sarif'
           fail-on-error: 'false'
@@ -87,20 +87,28 @@ ShipLint checks for common rejection reasons:
 
 | Rule ID | Description |
 |---------|-------------|
-| `missing-camera-purpose` | Camera usage without NSCameraUsageDescription |
-| `missing-location-purpose` | Location usage without purpose string |
-| `location-always-unjustified` | Always-on location without justification |
-| `att-tracking-mismatch` | ATT framework without NSUserTrackingUsageDescription |
-| `third-party-login-no-siwa` | Third-party login without Sign in with Apple |
-| `missing-privacy-manifest` | Missing PrivacyInfo.xcprivacy file |
-| `ats-exception-without-justification` | ATS exceptions without justification |
+| `privacy-001-missing-camera-purpose` | Camera usage without `NSCameraUsageDescription` |
+| `privacy-002-missing-location-purpose` | Location usage without a purpose string |
+| `privacy-003-att-tracking-mismatch` | Tracking SDKs without ATT / purpose string |
+| `privacy-004-missing-photo-library-purpose` | Photo library usage without purpose string |
+| `privacy-005-missing-microphone-purpose` | Microphone usage without purpose string |
+| `privacy-006-missing-contacts-purpose` | Contacts usage without purpose string |
+| `privacy-007-location-always-unjustified` | Always-on location without justification |
+| `privacy-008-missing-bluetooth-purpose` | Bluetooth usage without purpose string |
+| `privacy-009-missing-face-id-purpose` | Face ID usage without purpose string |
+| `auth-001-third-party-login-no-siwa` | Third‑party login without Sign in with Apple |
+| `metadata-001-missing-privacy-manifest` | Missing `PrivacyInfo.xcprivacy` when required |
+| `metadata-002-missing-supported-orientations` | Missing supported orientations config |
+| `config-001-ats-exception-without-justification` | ATS exceptions without justification |
+| `config-002-missing-encryption-flag` | Missing export compliance encryption flag |
+| `config-003-missing-launch-storyboard` | Missing launch storyboard config |
 
 ## Examples
 
 ### Scan specific path
 
 ```yaml
-- uses: Signal26AI/ShipLint@v1
+- uses: Signal26AI/ShipLint/action@v1
   with:
     path: 'ios/MyApp'
 ```
@@ -108,23 +116,23 @@ ShipLint checks for common rejection reasons:
 ### Run specific rules only
 
 ```yaml
-- uses: Signal26AI/ShipLint@v1
+- uses: Signal26AI/ShipLint/action@v1
   with:
-    rules: 'missing-camera-purpose,missing-location-purpose'
+    rules: 'privacy-001-missing-camera-purpose,privacy-002-missing-location-purpose'
 ```
 
 ### Exclude rules
 
 ```yaml
-- uses: Signal26AI/ShipLint@v1
+- uses: Signal26AI/ShipLint/action@v1
   with:
-    exclude: 'ats-exception-without-justification'
+    exclude: 'config-001-ats-exception-without-justification'
 ```
 
 ### Don't fail on issues (report only)
 
 ```yaml
-- uses: Signal26AI/ShipLint@v1
+- uses: Signal26AI/ShipLint/action@v1
   with:
     fail-on-error: 'false'
 ```
@@ -139,7 +147,7 @@ jobs:
         project: [apps/ios, apps/watchos]
     steps:
       - uses: actions/checkout@v4
-      - uses: Signal26AI/ShipLint@v1
+      - uses: Signal26AI/ShipLint/action@v1
         with:
           path: ${{ matrix.project }}
 ```

--- a/action/examples/workflow.yml
+++ b/action/examples/workflow.yml
@@ -1,8 +1,8 @@
-# ReviewShield GitHub Action - Example Workflow
+# ShipLint GitHub Action - Example Workflow
 # 
-# Add this file to your repo at: .github/workflows/reviewshield.yml
+# Add this file to your repo at: .github/workflows/shiplint.yml
 
-name: ReviewShield
+name: ShipLint
 
 on:
   pull_request:
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Run ReviewShield
+      - name: Run ShipLint
         uses: Signal26AI/ShipLint/action@v1
         with:
           path: '.'
@@ -29,7 +29,7 @@ jobs:
 ---
 # Alternative: SARIF output for GitHub Security tab
 
-name: ReviewShield (Security Tab)
+name: ShipLint (Security Tab)
 
 on:
   pull_request:
@@ -38,7 +38,7 @@ on:
 
 jobs:
   scan:
-    name: ReviewShield Security Scan
+    name: ShipLint Security Scan
     runs-on: ubuntu-latest
     permissions:
       security-events: write  # Required for uploading SARIF
@@ -48,8 +48,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       
-      - name: Run ReviewShield
-        id: reviewshield
+      - name: Run ShipLint
+        id: shiplint
         uses: Signal26AI/ShipLint/action@v1
         with:
           path: '.'
@@ -59,12 +59,12 @@ jobs:
       - name: Upload SARIF to GitHub Security
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: reviewshield-results.sarif
+          sarif_file: shiplint-results.sarif
 
 ---
 # Alternative: Monorepo with multiple iOS projects
 
-name: ReviewShield (Monorepo)
+name: ShipLint (Monorepo)
 
 on:
   pull_request:
@@ -89,7 +89,7 @@ jobs:
 ---
 # Alternative: Custom rule selection
 
-name: ReviewShield (Custom Rules)
+name: ShipLint (Custom Rules)
 
 on:
   pull_request:
@@ -100,15 +100,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Run ReviewShield (privacy rules only)
+      - name: Run ShipLint (privacy rules only)
         uses: Signal26AI/ShipLint/action@v1
         with:
           path: '.'
-          rules: 'missing-camera-purpose,missing-location-purpose,att-tracking-mismatch'
+          rules: 'privacy-001-missing-camera-purpose,privacy-002-missing-location-purpose,privacy-003-att-tracking-mismatch'
       
       # Or exclude specific rules
-      - name: Run ReviewShield (exclude low-priority)
+      - name: Run ShipLint (exclude low-priority)
         uses: Signal26AI/ShipLint/action@v1
         with:
           path: '.'
-          exclude: 'ats-exception-without-justification'
+          exclude: 'config-001-ats-exception-without-justification'

--- a/typescript/CHANGELOG.md
+++ b/typescript/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to ReviewShield will be documented in this file.
+All notable changes to ShipLint will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Bug #4: Swift CLI placeholder removed
 - Removed Swift CLI (`Sources/`) which only printed "implementation in progress"
 - Removed `Package.swift` and Swift `Tests/` directory
-- ReviewShield is now TypeScript-only as originally intended after pivot
+- ShipLint is now TypeScript-only as originally intended after pivot
 
 ### Changed
 - `ScanOptions.format` and `ScanOptions.verbose` are now optional

--- a/typescript/src/parsers/project-parser.ts
+++ b/typescript/src/parsers/project-parser.ts
@@ -646,7 +646,8 @@ export function createScanContext(discovery: ProjectDiscovery): ScanContext {
     linkedFrameworks,
     dependencies,
     discovery.infoPlistPath,
-    discovery.entitlementsPath
+    discovery.entitlementsPath,
+    discovery.pbxprojPath
   );
 }
 
@@ -660,7 +661,8 @@ export function createContextObject(
   linkedFrameworks: Set<string>,
   dependencies: Dependency[],
   infoPlistPath?: string,
-  entitlementsPath?: string
+  entitlementsPath?: string,
+  pbxprojPath?: string
 ): ScanContext {
   return {
     projectPath,
@@ -668,6 +670,7 @@ export function createContextObject(
     infoPlistPath,
     entitlements,
     entitlementsPath,
+    pbxprojPath,
     linkedFrameworks,
     dependencies,
     

--- a/typescript/src/rules/auth/third-party-login-no-siwa.ts
+++ b/typescript/src/rules/auth/third-party-login-no-siwa.ts
@@ -93,7 +93,7 @@ Important: Sign in with Apple must be presented as an equivalent option - same `
           description: `Your app has the Sign in with Apple capability enabled but ` +
             `AuthenticationServices framework doesn't appear to be linked. This may indicate ` +
             `an incomplete SIWA implementation.`,
-          location: 'Project',
+          location: context.pbxprojPath,
           fixGuidance: `Ensure you're importing AuthenticationServices and implementing the sign-in flow:
 
 import AuthenticationServices

--- a/typescript/src/rules/config/ats-exception-without-justification.ts
+++ b/typescript/src/rules/config/ats-exception-without-justification.ts
@@ -34,6 +34,7 @@ export const ATSExceptionWithoutJustificationRule: Rule = {
     }
 
     const findings: Finding[] = [];
+    const location = context.infoPlistPath || 'Info.plist';
     
     const allowsArbitraryLoads = atsConfig[ALLOWS_ARBITRARY_LOADS_KEY] as boolean | undefined;
     const allowsArbitraryLoadsWebView = atsConfig[ALLOWS_ARBITRARY_LOADS_WEBVIEW_KEY] as boolean | undefined;
@@ -50,7 +51,7 @@ export const ATSExceptionWithoutJustificationRule: Rule = {
             `This disables App Transport Security for ALL network connections, which is a significant ` +
             `security risk. Apple will require justification during App Store review and may reject ` +
             `your app if there's no valid reason.`,
-          location: 'Info.plist (NSAppTransportSecurity)',
+          location,
           fixGuidance: `Instead of disabling ATS entirely, configure specific exceptions for domains that ` +
             `require HTTP:
 
@@ -84,7 +85,7 @@ If you must use NSAllowsArbitraryLoads, you'll need to provide App Store Connect
           description: `Your app has both NSAllowsArbitraryLoads = true AND specific NSExceptionDomains. ` +
             `This is an unusual configuration. If you're using exception domains, you likely don't ` +
             `need NSAllowsArbitraryLoads at all.`,
-          location: 'Info.plist (NSAppTransportSecurity)',
+          location,
           fixGuidance: `Consider removing NSAllowsArbitraryLoads and keeping only NSExceptionDomains for ` +
             `the specific domains that need HTTP access. This provides better security by limiting ` +
             `insecure connections to only the domains you've explicitly allowed.
@@ -106,7 +107,7 @@ The exception domains are ignored when NSAllowsArbitraryLoads is true.`,
         description: `NSAllowsArbitraryLoadsInWebContent is set to true, allowing web views to load ` +
           `insecure HTTP content. While this is less severe than NSAllowsArbitraryLoads, it still ` +
           `represents a security consideration.`,
-        location: 'Info.plist (NSAppTransportSecurity)',
+        location,
         fixGuidance: `If your app needs to display arbitrary web content (like a browser), this setting ` +
           `may be justified. However, if your web views only load content from known sources, consider:
 
@@ -148,7 +149,7 @@ The exception domains are ignored when NSAllowsArbitraryLoads is true.`,
             title: `Insecure HTTP Allowed for ${domain}`,
             description: `Domain "${domain}" allows insecure HTTP connections without specifying ` +
               `a minimum TLS version. Consider if this domain can support HTTPS.`,
-            location: 'Info.plist (NSExceptionDomains)',
+            location,
             fixGuidance: `If the server supports TLS, add NSExceptionMinimumTLSVersion:
 
 <key>${domain}</key>

--- a/typescript/src/rules/privacy/att-tracking-mismatch.ts
+++ b/typescript/src/rules/privacy/att-tracking-mismatch.ts
@@ -106,7 +106,7 @@ Users should understand what tracking means for their privacy.`,
         title: 'AppTrackingTransparency Framework Not Linked',
         description: `Your app has NSUserTrackingUsageDescription but AppTrackingTransparency framework ` +
           `does not appear to be linked. This may indicate an incomplete ATT implementation.`,
-        location: 'Project',
+        location: context.pbxprojPath,
         fixGuidance: `Ensure you're importing AppTrackingTransparency in your code and actually showing ` +
           `the tracking permission prompt to users.
 

--- a/typescript/src/types/index.ts
+++ b/typescript/src/types/index.ts
@@ -103,6 +103,7 @@ export interface ScanContext {
   infoPlistPath?: string;
   entitlements: Record<string, unknown>;
   entitlementsPath?: string;
+  pbxprojPath?: string;
   linkedFrameworks: Set<string>;
   dependencies: Dependency[];
   

--- a/typescript/tests/rules/ats-exception-without-justification.test.ts
+++ b/typescript/tests/rules/ats-exception-without-justification.test.ts
@@ -6,6 +6,28 @@ import { createContextObject } from '../../src/parsers/project-parser';
 import { Severity, Confidence } from '../../src/types';
 
 describe('ATSExceptionWithoutJustificationRule', () => {
+  it('should use the real Info.plist file path as the finding location', async () => {
+    const infoPlistPath = '/test/project/Info.plist';
+    const context = createContextObject(
+      '/test/project',
+      {
+        CFBundleIdentifier: 'com.example.app',
+        NSAppTransportSecurity: {
+          NSAllowsArbitraryLoads: true,
+        },
+      },
+      {},
+      new Set(['UIKit']),
+      [],
+      infoPlistPath
+    );
+
+    const findings = await ATSExceptionWithoutJustificationRule.evaluate(context);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].location).toBe(infoPlistPath);
+  });
+
   it('should return no findings when no ATS configuration exists', async () => {
     const context = createContextObject(
       '/test/project',

--- a/typescript/tests/rules/att-tracking-mismatch.test.ts
+++ b/typescript/tests/rules/att-tracking-mismatch.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Tests for ATTTrackingMismatchRule
+ */
+import { ATTTrackingMismatchRule } from '../../src/rules/privacy/att-tracking-mismatch';
+import { createContextObject } from '../../src/parsers/project-parser';
+import { Severity, Confidence, DependencySource } from '../../src/types';
+
+describe('ATTTrackingMismatchRule', () => {
+  it('should point to project.pbxproj when ATT framework is missing', async () => {
+    const pbxprojPath = '/test/project/MyApp.xcodeproj/project.pbxproj';
+    const context = createContextObject(
+      '/test/project',
+      {
+        CFBundleIdentifier: 'com.example.app',
+        NSUserTrackingUsageDescription: 'We use tracking to measure and improve our ads performance.',
+      },
+      {},
+      new Set(['UIKit']), // No AppTrackingTransparency
+      [{ name: 'FirebaseAnalytics', version: '10.0.0', source: DependencySource.CocoaPods }],
+      undefined,
+      undefined,
+      pbxprojPath
+    );
+
+    const findings = await ATTTrackingMismatchRule.evaluate(context);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe(Severity.Medium);
+    expect(findings[0].confidence).toBe(Confidence.Medium);
+    expect(findings[0].title).toBe('AppTrackingTransparency Framework Not Linked');
+    expect(findings[0].location).toBe(pbxprojPath);
+  });
+});

--- a/typescript/tests/rules/third-party-login-no-siwa.test.ts
+++ b/typescript/tests/rules/third-party-login-no-siwa.test.ts
@@ -74,6 +74,7 @@ describe('ThirdPartyLoginNoSIWARule', () => {
   });
 
   it('should warn about missing AuthenticationServices when SIWA entitlement exists', async () => {
+    const pbxprojPath = '/test/project/MyApp.xcodeproj/project.pbxproj';
     const context = createContextObject(
       '/test/project',
       { CFBundleIdentifier: 'com.example.app' },
@@ -81,7 +82,10 @@ describe('ThirdPartyLoginNoSIWARule', () => {
       new Set(['UIKit']),  // No AuthenticationServices
       [
         { name: 'GoogleSignIn', version: '6.0.0', source: DependencySource.CocoaPods },
-      ]
+      ],
+      undefined,
+      undefined,
+      pbxprojPath
     );
 
     const findings = await ThirdPartyLoginNoSIWARule.evaluate(context);
@@ -89,6 +93,7 @@ describe('ThirdPartyLoginNoSIWARule', () => {
     expect(findings).toHaveLength(1);
     expect(findings[0].severity).toBe(Severity.Medium);
     expect(findings[0].title).toBe('Sign in with Apple May Not Be Implemented');
+    expect(findings[0].location).toBe(pbxprojPath);
   });
 
   it('should have lower confidence for Firebase Auth only', async () => {


### PR DESCRIPTION
## Summary
- redirect workflow docs and examples to `Signal26AI/ShipLint/action@v1`, refresh rule IDs, and update changelog branding
- propagate `pbxprojPath` through the project parser and rule context so SIWA/ATT/ATS findings report the actual Xcode file
- add regression tests that assert the new location metadata for ATT/ATS/SIWA checks

## Testing
- Not run (not requested)