### PR TITLE
Redesign CLI output: Rust-style diagnostics + Xcode formatter

### DIFF
--- a/typescript/src/cli/index.ts
+++ b/typescript/src/cli/index.ts
@@ -15,6 +15,8 @@ import packageJson from '../../package.json';
 
 const program = new Command();
 
+type CliOutputFormat = OutputFormat | 'xcode';
+
 program
   .name('shiplint')
   .description('App Store Review Guideline scanner for iOS projects')
@@ -24,7 +26,7 @@ program
   .command('scan')
   .description('Scan an Xcode project for potential App Store Review issues')
   .argument('<path>', 'Path to Xcode project, workspace, or directory')
-  .option('-f, --format <format>', 'Output format: text, json, sarif', 'text')
+  .option('-f, --format <format>', 'Output format: text, json, sarif, xcode', 'text')
   .option('-v, --verbose', 'Show verbose output', false)
   .option('-r, --rules <rules...>', 'Only run specific rules (by ID)')
   .option('-e, --exclude <rules...>', 'Exclude specific rules (by ID)')
@@ -35,7 +37,7 @@ program
       
       const result = await scan({
         path,
-        format: outputFormat,
+        format: outputFormat === 'xcode' ? OutputFormat.Text : outputFormat,
         verbose: options.verbose,
         rules: options.rules,
         exclude: options.exclude,
@@ -121,7 +123,7 @@ program
     }
   });
 
-function parseOutputFormat(format: string): OutputFormat {
+function parseOutputFormat(format: string): CliOutputFormat {
   switch (format.toLowerCase()) {
     case 'text':
       return OutputFormat.Text;
@@ -129,8 +131,10 @@ function parseOutputFormat(format: string): OutputFormat {
       return OutputFormat.JSON;
     case 'sarif':
       return OutputFormat.SARIF;
+    case 'xcode':
+      return 'xcode';
     default:
-      throw new Error(`Unknown output format: ${format}. Use text, json, or sarif.`);
+      throw new Error(`Unknown output format: ${format}. Use text, json, sarif, or xcode.`);
   }
 }
 

--- a/typescript/src/formatters/index.ts
+++ b/typescript/src/formatters/index.ts
@@ -6,15 +6,17 @@ import { OutputFormat } from '../types/index.js';
 import { formatText } from './text.js';
 import { formatJSON } from './json.js';
 import { formatSARIF } from './sarif.js';
+import { formatXcode } from './xcode.js';
 
 export { formatText } from './text.js';
 export { formatJSON, formatJSONCompact } from './json.js';
 export { formatSARIF } from './sarif.js';
+export { formatXcode } from './xcode.js';
 
 /**
  * Format scan results based on output format
  */
-export async function format(result: ScanResult, outputFormat: OutputFormat): Promise<string> {
+export async function format(result: ScanResult, outputFormat: OutputFormat | 'xcode'): Promise<string> {
   switch (outputFormat) {
     case OutputFormat.Text:
       return formatText(result);
@@ -22,5 +24,7 @@ export async function format(result: ScanResult, outputFormat: OutputFormat): Pr
       return formatJSON(result);
     case OutputFormat.SARIF:
       return formatSARIF(result);
+    case 'xcode':
+      return formatXcode(result);
   }
 }

--- a/typescript/src/formatters/xcode.ts
+++ b/typescript/src/formatters/xcode.ts
@@ -1,0 +1,25 @@
+/**
+ * Xcode formatter for native warning presentation in Xcode build logs
+ * Format: file:line:col: warning: message (rule_id)
+ */
+import type { ScanResult } from '../types/index.js';
+
+function sanitizeLocation(location: string): string {
+  return location.replace(/\r?\n/g, ' ').trim();
+}
+
+export function formatXcode(result: ScanResult): string {
+  if (result.findings.length === 0) {
+    return '';
+  }
+
+  return result.findings
+    .map((finding) => {
+      const file = sanitizeLocation(finding.location ?? result.projectPath);
+      const line = finding.line ?? 1;
+      const column = 1;
+      const message = finding.title.replace(/\r?\n/g, ' ').trim();
+      return `${file}:${line}:${column}: warning: ${message} (${finding.ruleId})`;
+    })
+    .join('\n');
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -29,4 +29,4 @@ export { scan, scanWithContext } from './core/scanner.js';
 export { applySuppression, parseShiplintIgnore, loadShiplintIgnore } from './core/suppression.js';
 
 // Formatters
-export { format, formatText, formatJSON, formatSARIF } from './formatters/index.js';
+export { format, formatText, formatJSON, formatSARIF, formatXcode } from './formatters/index.js';

--- a/typescript/tests/formatters/cli-output-redesign.test.ts
+++ b/typescript/tests/formatters/cli-output-redesign.test.ts
@@ -1,0 +1,88 @@
+// Mock chalk to avoid ESM issues in Jest
+const passthrough = (text: string) => text;
+const handler: ProxyHandler<any> = {
+  get: (_target: any, prop: string) => {
+    if (prop === 'default') return new Proxy(passthrough, handler);
+    if (prop === '__esModule') return true;
+    if (prop === 'then') return undefined;
+    return new Proxy(passthrough, handler);
+  },
+  apply: (_target: any, _thisArg: any, args: any[]) => args[0],
+};
+jest.mock('chalk', () => new Proxy(passthrough, handler));
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { formatText } from '../../src/formatters/text.js';
+import { formatXcode } from '../../src/formatters/xcode.js';
+import { Severity, Confidence } from '../../src/types/index.js';
+import type { ScanResult, Finding } from '../../src/types/index.js';
+
+function makeFinding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    ruleId: 'privacy-010',
+    severity: Severity.Medium,
+    confidence: Confidence.High,
+    title: 'Missing privacy manifest declaration',
+    description: 'Privacy manifest declaration is missing.',
+    location: 'Sources/App.swift',
+    line: 2,
+    guideline: '5.1.1',
+    fixGuidance: 'Add NSPrivacyAccessedAPICategoryUserDefaults with reason CA92.1',
+    documentationURL: 'https://shiplint.app/errors/itms-91053',
+    ...overrides,
+  };
+}
+
+function makeResult(projectPath: string, findings: Finding[]): ScanResult {
+  return {
+    projectPath,
+    timestamp: new Date('2026-01-01T00:00:00.000Z'),
+    findings,
+    suppressedFindings: [],
+    rulesRun: ['privacy-010'],
+    duration: 42,
+    projectType: 'xcodeproj',
+    frameworkDetectionMethod: 'pbxproj',
+    frameworksDetected: [],
+    targetCount: 1,
+  };
+}
+
+describe('CLI output redesign', () => {
+  test('text formatter shows rust-style diagnostic when location + line are available', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'shiplint-format-'));
+    const srcDir = path.join(tmp, 'Sources');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(srcDir, 'App.swift'),
+      ['import Foundation', 'let saved = UserDefaults.standard.bool(forKey: "onboarded")', 'if saved { return }'].join('\n')
+    );
+
+    const output = await formatText(makeResult(tmp, [makeFinding()]));
+
+    expect(output).toContain('Sources/App.swift:2:');
+    expect(output).toContain('privacy-010 [MEDIUM] Missing privacy manifest declaration');
+    expect(output).toContain('^');
+    expect(output).toContain('= help: Add NSPrivacyAccessedAPICategoryUserDefaults with reason CA92.1');
+    expect(output).toContain('= docs: https://shiplint.app/errors/itms-91053');
+    expect(output).toContain('Checked 1 files in 42ms');
+  });
+
+  test('text formatter degrades gracefully without source line info', async () => {
+    const finding = makeFinding({ location: undefined, line: undefined });
+    const output = await formatText(makeResult('/tmp/project', [finding]));
+
+    expect(output).toContain('privacy-010 [MEDIUM] Missing privacy manifest declaration');
+    expect(output).toContain('description: Privacy manifest declaration is missing.');
+    expect(output).toContain('help: Add NSPrivacyAccessedAPICategoryUserDefaults with reason CA92.1');
+  });
+
+  test('xcode formatter emits native warning lines', () => {
+    const output = formatXcode(makeResult('/tmp/project', [makeFinding()]));
+    expect(output).toBe(
+      'Sources/App.swift:2:1: warning: Missing privacy manifest declaration (privacy-010)'
+    );
+  });
+});


### PR DESCRIPTION
## Summary\n- upgraded text formatter to Rust-style diagnostics while preserving verdict banner + severity grouping\n- added new `--format xcode` formatter for native Xcode warnings\n- added clean summary footer with checked files and severity rollup\n- added formatter tests for redesigned text output and xcode output\n\n## Details\n- text findings with location+line now render with:\n  - `file:line:col:` header\n  - source context block + caret marker\n  - help/docs lines\n- findings without source line degrade to a clean block format\n- CLI now accepts `--format xcode`\n\n## Validation\n- `cd typescript && npm test` (all passing)\n- `cd typescript && npm run build`